### PR TITLE
Fix a bug due to Python binary selection by cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ execute_process(COMMAND ${CMAKE_GET} bpo OUTPUT_VARIABLE BPO)
 
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${PROJECT_SOURCE_DIR}/cmake")
 
+set(Python_ADDITIONAL_VERSIONS 2.7 2.6)
+
 #
 # Find packages
 #
@@ -47,10 +49,7 @@ find_package(FUSE REQUIRED)
 find_package(READLINE REQUIRED)
 find_package(SWIG REQUIRED)
 find_package(Doxygen QUIET)
-find_program(PYTHON NAMES python2.7)
-if(NOT PYTHON)
-  find_program(PYTHON NAMES python2.6)
-endif(NOT PYTHON)
+find_package(PythonInterp REQUIRED)
 
 find_program(DEBUILD NAMES debuild)
 find_program(DEBUILD NAMES debuild)

--- a/cmake/setup.cmake
+++ b/cmake/setup.cmake
@@ -1,6 +1,7 @@
 set (WDIR "" CACHE FORCE "Working Directory")
 set (PREFIX "" CACHE FORCE "Prefix")
 set (SETUP "" CACHE FORCE "Path to setup.py")
+set (PYTHON_EXEC "" CACHE FORCE "Python version")
 set (DEBIAN "" CACHE FORCE "Debian layout")
 set (MANIFEST "" CACHE FORCE "Manifest file")
 set (INSTALL_ROOT $ENV{DESTDIR})
@@ -18,4 +19,4 @@ endif (INSTALL_ROOT)
 
 #cmake_policy (SET CMP0012 NEW)
 
-execute_process (COMMAND python ${SETUP} install ${EXTRA_ARGS} --prefix=${PREFIX} --record=${MANIFEST} ${INSTALL_ROOT_ARGS} WORKING_DIRECTORY ${WDIR})
+execute_process (COMMAND ${PYTHON_EXECUTABLE} ${SETUP} install ${EXTRA_ARGS} --prefix=${PREFIX} --record=${MANIFEST} ${INSTALL_ROOT_ARGS} WORKING_DIRECTORY ${WDIR})

--- a/manager/CMakeLists.txt
+++ b/manager/CMakeLists.txt
@@ -26,6 +26,6 @@ if (NOT PYTHON_NOTFOUND)
 
     add_custom_target(manager ALL DEPENDS ${OUTPUT})
 
-    install(CODE "execute_process (COMMAND cmake -DSETUP=${CMAKE_BINARY_DIR}/manager/setup.py -DDEBIAN=${DEBIAN_LAYOUT} -DPREFIX=${CMAKE_INSTALL_PREFIX} -DMANIFEST=${PROJECT_BINARY_DIR}/manager_install_manifest.txt -DWDIR=${CMAKE_CURRENT_BINARY_DIR} -P ${PROJECT_SOURCE_DIR}/cmake/setup.cmake)")
+    install(CODE "execute_process (COMMAND cmake -DSETUP=${CMAKE_BINARY_DIR}/manager/setup.py -DDEBIAN=${DEBIAN_LAYOUT} -DPREFIX=${CMAKE_INSTALL_PREFIX} -DMANIFEST=${PROJECT_BINARY_DIR}/manager_install_manifest.txt -DWDIR=${CMAKE_CURRENT_BINARY_DIR} -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE} -P ${PROJECT_SOURCE_DIR}/cmake/setup.cmake)")
 
 endif(NOT PYTHON_NOTFOUND)


### PR DESCRIPTION
**Bug:**
    `$ sudo make install`
    deploys Python related files into the wrong version and installation fails:

**Obs:**
```bash
$ sudo make install
(...)
running build
running build_py
copying /home/dim/git/rozofs/manager/rozofs/__init__.py -> build/lib.linux-x86_64-3.5/rozofs
copying /home/dim/git/rozofs/manager/rozofs/core/libconfig.py -> build/lib.linux-x86_64-3.5/rozofs/core
running build_ext
running build_scripts
running install_lib
copying build/lib.linux-x86_64-3.5/rozofs/core/libconfig.py -> /usr/local/lib/python3.5/site-packages/rozofs/core
copying build/lib.linux-x86_64-3.5/rozofs/__init__.py -> /usr/local/lib/python3.5/site-packages/rozofs
byte-compiling /usr/local/lib/python3.5/site-packages/rozofs/cli/volume.py to volume.cpython-35.pyc
byte-compiling /usr/local/lib/python3.5/site-packages/rozofs/core/agent.py to agent.cpython-35.pyc
byte-compiling /usr/local/lib/python3.5/site-packages/rozofs/__init__.py to __init__.cpython-35.pyc
running install_scripts
changing mode of /usr/local/bin/rozo to 755
running install_egg_info
Removing /usr/local/lib/python3.5/site-packages/rozofs_manager-1.6._alpha5-py3.5.egg-info
Writing /usr/local/lib/python3.5/site-packages/rozofs_manager-1.6._alpha5-py3.5.egg-info
writing list of installed files to '/home/dim/git/rozofs/build/manager_install_manifest.txt'
  File "/usr/local/lib/python3.5/site-packages/rozofs/cli/volume.py", line 70
    print 'WARNING: %s is not reachable' % str(host)
                                       ^
SyntaxError: invalid syntax

  File "/usr/local/lib/python3.5/site-packages/rozofs/core/agent.py", line 81
    oldmask = os.umask(022)
                         ^
SyntaxError: invalid token
```

```bash
$ uname -a
Linux r2d2 4.2.5-1-ARCH #1 SMP PREEMPT Tue Oct 27 08:13:28 CET 2015 x86_64 GNU/Linux
```

**Problem:**
	Here, files are managed by python3.5 since we target `/usr/bin/python`.

**Solution:**
PythonInterp is proposed for better determination of the python2.7 or python2.6 executable path.