### PR TITLE
missing attr Requires for rozofsmount

### DIFF
--- a/cmake/rozofs.spec.in
+++ b/cmake/rozofs.spec.in
@@ -49,7 +49,7 @@ RozoFS storaged daemon stores encoded data for the RozoFS filesystems.
 Summary: RozoFS filesystem (mount utility package).
 License: GPLv2
 Group: System Environment/File
-Requires: fuse >= 2.9, rozofs-rozolauncher numactl libconfig
+Requires: fuse >= 2.9, rozofs-rozolauncher numactl libconfig attr
 %description rozofsmount
 rozofsmount mounts RozoFS filesystems using FUSE.
 


### PR DESCRIPTION
/usr/bin/rozo_clusterstats.sh needs attr to work properly. Command not installed with minimal install on CentOS 7, and provided by attr package.