### PR TITLE
Fix parsing of values not surrounded by spaces in test_storage_io

### DIFF
--- a/contrib/nagios/plugins/check_rozofs_storaged.sh
+++ b/contrib/nagios/plugins/check_rozofs_storaged.sh
@@ -170,8 +170,8 @@ test_storage_io()
    };;  
   esac
   
-  read=`awk '{if ($1=="read") print $9; }' $TMPFILE`
-  write=`awk '{if ($1=="write") print $9; }' $TMPFILE`
+  read=`awk 'BEGIN { FS=" *[|] *" } ; {if ($1=="read") print $5; }' $TMPFILE`
+  write=`awk 'BEGIN { FS=" *[|] *" } ; {if ($1=="write") print $5; }' $TMPFILE`
   all_read=$((all_read+read))
   all_write=$((all_write+write))
   


### PR DESCRIPTION
Fixes #126.

Untested, but simple enough: instead of splitting on spaces, split on the regex ` *[|] *`, i.e. any number of spaces, a pipe, and any number of spaces.  I didn't split on pipe alone to keep the fields space-free, making it easy to keep the `if ($1 == "write")` without having to worry about spaces surrounding it.

It's likely the other `awk` calls should be updated in a similar way.  It'd be fairly easy, but should better be done by someone with actual data to test the new fields numbers.