### PR TITLE
Be verbose during Python package build

### DIFF
--- a/manager/CMakeLists.txt
+++ b/manager/CMakeLists.txt
@@ -20,7 +20,7 @@ if (NOT PYTHON_NOTFOUND)
     set(OUTPUT      "${CMAKE_CURRENT_BINARY_DIR}/timestamp")
 
     add_custom_command(OUTPUT ${OUTPUT}
-                       COMMAND ${PYTHON} setup.py --quiet build
+                       COMMAND ${PYTHON} setup.py build
                        COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
                        DEPENDS ${DEPS})
 


### PR DESCRIPTION
Debian requires the build log to show all gcc invocations with full
parameters. Also this makes it easier to debug problems related to build
flags. Right now for example, the build is failing when we enable
the PIE build flags and I need to see the command line to be able
to work on a fix.
