### PR TITLE
Disable -pie in LDFLAGS in the Python package build

### DIFF
--- a/cmake/setup.py.in
+++ b/cmake/setup.py.in
@@ -1,9 +1,15 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+import os
+
 from distutils.core import setup
 from distutils.command.build_py import build_py
 from distutils.extension import Extension
+
+if 'LDFLAGS' in os.environ:
+    os.environ['LDFLAGS'] = os.environ['LDFLAGS'].replace("-pie", "")
+
 
 class version_build_py(build_py):
     """Specialized Python source builder."""


### PR DESCRIPTION
-pie is a gcc linker flag that we enable in Debian to build hardened binaries (see
https://wiki.debian.org/Hardening) but it can break the build for some libraries and
might need upstream build system adjustment as is the case here, since we get a
build failure in the Python library:
cd /<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/manager && /usr/bin/python2.7 setup.py build
[...]
/usr/lib/gcc/x86_64-linux-gnu/6/../../../x86_64-linux-gnu/Scrt1.o: In function `_start':
(.text+0x20): undefined reference to`main'

Thus we want to explicitly disable the -pie flag in setup.py.
